### PR TITLE
Correção para que os posts passem a aparecer

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,10 +2,6 @@
 markdown:         redcarpet
 highlighter:      pygments
 
-# Permalinks
-permalink:        pretty
-relative_permalinks: true
-
 # Setup
 title:            Marquinhus Goncalves
 tagline:          'blog sobre desenvolvimento'
@@ -18,6 +14,7 @@ author:
 
 # Custom vars
 version:          1.0
+paginate: 5
 
 github:           https://github.com/marquinhusgoncalves
 twitter:          https://twitter.com/marquinhusgonc


### PR DESCRIPTION
Conforme o seu arquivo [index.html](https://github.com/marquinhusgoncalves/marquinhusgoncalves.github.io/blob/master/index.html#L7), na linha 7 você define que irá chamar os posts através do `paginator`, para que este funcione, ele guarda os posts dentro desse array e os retorna de acordo com o limite definido pelo `paginate`. Porém, para que o paginator funcione, você não pode definir permalinks, visto que ele já gera o próprio permalink.

O que eu fiz foi remover esta definição e setar um limite para paginação. Para que você entenda ainda melhor o funcionamento e consiga editar conforme suas necessidades, lhe aconselho dar uma lida na  [Documentação do Pagination do Jekyll](http://jekyllrb.com/docs/pagination/).

Espero ter ajudado =)
